### PR TITLE
Create a new farm mission

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>me.mrcookieslime</groupId>
 	<artifactId>QuestWorld</artifactId>
-	<version>2.8.1-SNAPSHOT</version>
+	<version>2.9</version>
 	<build>
 		<resources>
 			<resource>

--- a/src/main/java/com/questworld/extension/builtin/Builtin.java
+++ b/src/main/java/com/questworld/extension/builtin/Builtin.java
@@ -9,7 +9,7 @@ public class Builtin extends QuestExtension {
 	public Builtin() {
 		setMissionTypes(new CraftMission(), new SubmitMission(), new DetectMission(), new KillMission(),
 				new KillNamedMission(), new FishMission(), new LocationMission(), new JoinMission(), new PlayMission(),
-				new MineMission(), new LevelMission());
+				new MineMission(), new LevelMission(), new FarmMission());
 
 		Reflect.addAdapter(new CurrentAdapter());
 		try {

--- a/src/main/java/com/questworld/extension/builtin/FarmMission.java
+++ b/src/main/java/com/questworld/extension/builtin/FarmMission.java
@@ -1,0 +1,62 @@
+package com.questworld.extension.builtin;
+
+import com.questworld.api.Decaying;
+import com.questworld.api.MissionType;
+import com.questworld.api.QuestWorld;
+import com.questworld.api.contract.IMission;
+import com.questworld.api.contract.IMissionState;
+import com.questworld.api.contract.MissionEntry;
+import com.questworld.api.menu.MissionButton;
+import com.questworld.util.ItemBuilder;
+import com.questworld.util.Text;
+import org.bukkit.Material;
+import org.bukkit.block.data.Ageable;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.Collection;
+import java.util.Optional;
+
+public class FarmMission extends MissionType implements Listener, Decaying {
+
+    public FarmMission() {
+        super("FARM", true, new ItemStack(Material.IRON_HOE));
+    }
+
+    @Override
+    public ItemStack userDisplayItem(IMission instance) {
+        return instance.getItem();
+    }
+
+    @Override
+    protected String userInstanceDescription(IMission instance) {
+        return "&7Farm " + instance.getAmount() + "x " + Text.itemName(instance.getDisplayItem());
+    }
+
+    @EventHandler
+    public void onBreak(BlockBreakEvent e) {
+        if (e.getBlock().getBlockData() instanceof Ageable
+            && ((Ageable) e.getBlock().getBlockData()).getAge() == ((Ageable) e.getBlock().getBlockData()).getMaximumAge()
+        ) {
+            Collection<ItemStack> drops = e.getBlock().getDrops(e.getPlayer().getInventory().getItemInMainHand());
+            if (drops.isEmpty()) return;
+
+            Optional<ItemStack> crop = drops.stream().filter(is -> !is.getType().name().endsWith("_SEEDS")).findFirst();
+            if (!crop.isPresent()) return;
+
+            for (MissionEntry r : QuestWorld.getMissionEntries(this, e.getPlayer())) {
+                if (ItemBuilder.compareItems(crop.get(), r.getMission().getItem()))
+                    r.addProgress(1);
+            }
+        }
+    }
+
+    @Override
+
+    protected void layoutMenu(IMissionState changes) {
+        putButton(10, MissionButton.item(changes));
+        putButton(17, MissionButton.amount(changes));
+    }
+}


### PR DESCRIPTION
This mission allows players to break crops such as carrots, wheat and coco beans. Usually this wouldn't be possible, so I made a mission!

This will only do ageable crops, so not sugarcane but that can be achieved with block break. 

This has been tested on 1.14.4 and works as intended.